### PR TITLE
OM2-237 | Improve S3 moveTempToFinal method

### DIFF
--- a/src/Services/S3/Exception/S3Exception.php
+++ b/src/Services/S3/Exception/S3Exception.php
@@ -12,6 +12,7 @@ class S3Exception extends AbstractException
     const TYPE_S3_BUCKET_NAME_CANNOT_BLANK = "S3_BUCKET_NAME_CANNOT_BLANK";
     const TYPE_S3_BUCKET_CONFIG_NOT_FOUND  = "S3_BUCKET_CONFIG_NOT_FOUND";
     const TYPE_S3_BUCKET_NOT_FOUND         = "S3_BUCKET_NOT_FOUND";
+    const TYPE_FILES_DOESNT_EXIST          = "FILES_DOESNT_EXIST";
 
     /**
      * @inheritDoc
@@ -22,6 +23,7 @@ class S3Exception extends AbstractException
             self::TYPE_S3_BUCKET_NAME_CANNOT_BLANK => 400,
             self::TYPE_S3_BUCKET_CONFIG_NOT_FOUND  => 400,
             self::TYPE_S3_BUCKET_NOT_FOUND         => 400,
+            self::TYPE_FILES_DOESNT_EXIST          => 400,
         ];
     }
 }


### PR DESCRIPTION
This method moves item files from the temp dir to the final one.
It's used specially to avoid needing to wait for alpha actually move
the files to the connected_files S3 path, which can take until 5 min.

We're having some issues, where alpha actually sends a broken URL for
some temp files, for example:

```
https://s3.sa-east-1.amazonaws.com/fe-live-1/upload/temp/152899862850888106ThisIsTheFile.pdf
```

As can be noted, this URL's missing a forward slash right after the
"random" numeric hash, therefore we cannot either check if the file
exists or copy it to the final dir.

In order to fix this (as much as we can, at least), we're actually
adding the forward slash using a regex pattern to check where the
numeric sequence ends.

This fix won't work, however, when the filename actually starts with
numbers, because the regex will actualy capture those with the number
sequence.

Unfortunately, this sequence does not have a consistent length, making
it pretty much impossible to have a good accuracy here.

Although, this fix will already help in most cases.