### PR TITLE
Improving Bucket name handling

### DIFF
--- a/src/Services/AwsService.php
+++ b/src/Services/AwsService.php
@@ -87,4 +87,14 @@ abstract class AwsService
 
         return $this->config[$key];
     }
+
+    /**
+     * Returns the config array for this Bundle
+     *
+     * @return array
+     */
+    protected function getConfig(): array
+    {
+        return $this->config;
+    }
 }


### PR DESCRIPTION
Currently we sign files from both alpha and omega buckets. Although, as
our methods ask for bucket references, the client may not actually know
precisely which bucket they want to handle.

In order to improve this Bundle's usability, we know run a double-check
to make sure that the provided bucket reference matches the one where
the file is.

@todo: In a near future, we may remove the need of an explicit param,
since we're quite able to figure out by ourselves the bucket and key.
Although, we *must* throw some kind of Exception when the provided file
resides in a bucket we don't have explicitly declared on our configs.