### PR TITLE
Improved GetUrlInfo method to add region

### DIFF
--- a/src/Services/S3/Exception/S3Exception.php
+++ b/src/Services/S3/Exception/S3Exception.php
@@ -9,11 +9,12 @@ use Printi\AwsBundle\Exception\AbstractException;
  */
 class S3Exception extends AbstractException
 {
-    const TYPE_S3_BUCKET_NAME_CANNOT_BLANK = "S3_BUCKET_NAME_CANNOT_BLANK";
-    const TYPE_S3_BUCKET_CONFIG_NOT_FOUND  = "S3_BUCKET_CONFIG_NOT_FOUND";
-    const TYPE_S3_BUCKET_NOT_FOUND         = "S3_BUCKET_NOT_FOUND";
-    const TYPE_FILES_DOESNT_EXIST          = "FILES_DOESNT_EXIST";
-    const TYPE_S3_DIRECTORY_NOT_FOUND      = "S3_DIRECTORY_NOT_FOUND";
+    const TYPE_S3_BUCKET_NAME_CANNOT_BLANK      = "S3_BUCKET_NAME_CANNOT_BLANK";
+    const TYPE_S3_BUCKET_CONFIG_NOT_FOUND       = "S3_BUCKET_CONFIG_NOT_FOUND";
+    const TYPE_S3_BUCKET_NOT_FOUND              = "S3_BUCKET_NOT_FOUND";
+    const TYPE_FILES_DOESNT_EXIST               = "FILES_DOESNT_EXIST";
+    const TYPE_S3_DIRECTORY_NOT_FOUND           = "S3_DIRECTORY_NOT_FOUND";
+    const TYPE_COULD_NOT_GET_INFO_FROM_FILE_URL = "COULD_NOT_GET_INFO_FROM_FILE_URL";
 
     /**
      * @inheritDoc
@@ -21,11 +22,12 @@ class S3Exception extends AbstractException
     protected function populateCodeMap()
     {
         $this->codeMap = [
-            self::TYPE_S3_BUCKET_NAME_CANNOT_BLANK => 400,
-            self::TYPE_S3_BUCKET_CONFIG_NOT_FOUND  => 400,
-            self::TYPE_S3_BUCKET_NOT_FOUND         => 400,
-            self::TYPE_FILES_DOESNT_EXIST          => 400,
-            self::TYPE_S3_DIRECTORY_NOT_FOUND      => 400,
+            self::TYPE_S3_BUCKET_NAME_CANNOT_BLANK      => 400,
+            self::TYPE_S3_BUCKET_CONFIG_NOT_FOUND       => 400,
+            self::TYPE_S3_BUCKET_NOT_FOUND              => 400,
+            self::TYPE_FILES_DOESNT_EXIST               => 400,
+            self::TYPE_S3_DIRECTORY_NOT_FOUND           => 400,
+            self::TYPE_COULD_NOT_GET_INFO_FROM_FILE_URL => 400,
         ];
     }
 }


### PR DESCRIPTION
- Improved S3::getUrlInfo() method to add the region to the capture
groups, allowing us to generate a presigned URL even for buckets we may
not have all the configs for.

- Also made some adjustments on what we do when we can't parse the URL:
now we throw an exception instead of letting the process fail almost
silently by having a notice that a key is not set, since we returned an
empty array, which doesn't help by any means the caller.

- Changed a bit AwsService, making the properties protected instead of
private, since it's an abstract class.

Those, specially the 1st and 2nd points, will allow us to interact with
"legacy" orders that are not on the new OM2 S3 bucket standard paths.